### PR TITLE
Made HMI lowercase in "Running locally without the HMI" link since it…

### DIFF
--- a/td-modeling/delphi.md
+++ b/td-modeling/delphi.md
@@ -11,7 +11,7 @@ nav_order: 2
   - [Head nodes](#head-nodes)
   - [Editing an edge](#editing-an-edge)
   - [Interventions](#interventions)
-  - [Running locally without the HMI](#running-locally-without-the-HMI)
+  - [Running locally without the HMI](#running-locally-without-the-hmi)
   - [Further reading](#further-reading)
  
 # Delphi


### PR DESCRIPTION
… was not working in the browser.