### PR TITLE
Restructure INDRA World documentation

### DIFF
--- a/reading-assembly.md
+++ b/reading-assembly.md
@@ -105,8 +105,8 @@ Options for running the integrated system are described [here](reading-assembly/
 
 Systems used:
 * Document and ontology management: [DART](reading-assembly/dart.html#w5)
-* Readers: [Eidos](reading-assembly/eidos.html#w5), [HUME](reading-assembly/hume.html#w5)
-* Integration/assembly: [INDRA](reading-assembly/indra.html#w5)
+* Readers: [Eidos](reading-assembly/eidos_workflows.html#integrated-system), [HUME](reading-assembly/hume.html#w5)
+* Integration/assembly: [INDRA World](reading-assembly/indra_workflows.html#integrated-system)
 * HMI: [Causemos](reading-assembly/causemos.html#w5)
 
 ## Sub-system workflows
@@ -121,7 +121,7 @@ outputs for downstream usage.
 The following pages provide detailed instructions for running each reading
 system in a reading-only workflow:
 
-  * Readers: one of [Eidos](reading-assembly/eidos.html#w1), [HUME](reading-assembly/hume.html#w1), [Sofia](reading-assembly/sofia.html#w1)
+  * Readers: one of [Eidos](reading-assembly/eidos_workflows.html#reading-only), [HUME](reading-assembly/hume.html#w1), [Sofia](reading-assembly/sofia.html#w1)
 
 <a id="w2"></a>
 ### Reading + integration/assembly
@@ -135,8 +135,8 @@ components to create a coherent knowledge base. This section describes
 the usage of these components independent of the integrated system.
 
 Systems used:
-  * Readers: one or more of [Eidos](reading-assembly/eidos.html#w2), [HUME](reading-assembly/hume.html#w2), or [Sofia](reading-assembly/sofia.html#w2)
-  * Integration/assembly: [INDRA](reading-assembly/indra.html#w2)
+  * Readers: one or more of [Eidos](reading-assembly/eidos_workflows.html#reading-and-assembly), [HUME](reading-assembly/hume.html#w2), or [Sofia](reading-assembly/sofia.html#w2)
+  * Integration/assembly: [INDRA](reading-assembly/indra_workflows.html#reading-and-assembly)
 
 
 ## Component-specific documentation
@@ -146,7 +146,7 @@ Systems used:
 
     Eidos is the machine reading system developed by the CLU lab at University of Arizona.
   
-    Workflows: ([Reading only](reading-assembly/eidos.html#w1), [Reading and assembly](reading-assembly/eidos.html#w2), [Integrated](reading-assembly/eidos.html#w5))
+    Workflows: ([Reading only](reading-assembly/eidos_workflows.html#reading-only), [Reading and assembly](reading-assembly/eidos_workflows.html#reading-and-assembly), [Integrated](reading-assembly/eidos_workflows.html#integrated-system))
 
   * [HUME](reading-assembly/hume.html)
   
@@ -167,7 +167,7 @@ Systems used:
     standardizes their representation, finds ontological relationships between relations, calculates overall confidence,
     and has a configurable pipeline to process and filter causal knowledge.
   
-    Workflows: ([Reading and assembly](reading-assembly/indra.html#w2), [Integrated](reading-assembly/indra.html#w5))
+    Workflows: ([Reading and assembly](reading-assembly/indra_workflows.html#reading-and-assembly), [Integrated](reading-assembly/indra_workflows.html#integrated-system))
 
 * Document management
   * [DART](reading-assembly/dart.html)

--- a/reading-assembly.md
+++ b/reading-assembly.md
@@ -105,7 +105,7 @@ Options for running the integrated system are described [here](reading-assembly/
 
 Systems used:
 * Document and ontology management: [DART](reading-assembly/dart.html#w5)
-* Readers: [Eidos](reading-assembly/eidos.html#w5), [HUME](reading-assembly/hume.html#w5), [Sofia](reading-assembly/sofia.html#w5)
+* Readers: [Eidos](reading-assembly/eidos.html#w5), [HUME](reading-assembly/hume.html#w5)
 * Integration/assembly: [INDRA](reading-assembly/indra.html#w5)
 * HMI: [Causemos](reading-assembly/causemos.html#w5)
 
@@ -121,9 +121,7 @@ outputs for downstream usage.
 The following pages provide detailed instructions for running each reading
 system in a reading-only workflow:
 
-  * [Eidos](reading-assembly/eidos.html#w1)
-  * [HUME](reading-assembly/hume.html#w1)
-  * [Sofia](reading-assembly/sofia.html#w1)
+  * Readers: one of [Eidos](reading-assembly/eidos.html#w1), [HUME](reading-assembly/hume.html#w1), [Sofia](reading-assembly/sofia.html#w1)
 
 <a id="w2"></a>
 ### Reading + integration/assembly

--- a/reading-assembly/indra_workflows.md
+++ b/reading-assembly/indra_workflows.md
@@ -1,0 +1,72 @@
+---
+title: INDRA World workflows
+has_children: false
+parent: INDRA World
+nav_order: 1
+---
+## INDRA World Workflows
+
+## Contents
+* [Integrated system](#integrated-system)
+* [Reading and assembly](#reading-and-assembly)
+
+<a id="integrated-system"></a>
+### [Integrated system](index.html#integrated-system)
+
+INDRA World is part of the integrated Causal Relation Extraction and Assembly
+Toolkit where it serves as an integrator of reader outputs and incremental
+knowledge assembly. In this context, INDRA World is running as a containerized
+service and exposes a REST API to communicate with other components.
+This REST API is available at http://localhost:9444 by default.
+
+INDRA World also exposes an Assembly Dashboard where you can monitor
+(query for) reader outputs that have already been produced for some input
+documents, and filter these to define a scope for assembly. Then you can
+fill out some details to define and generate a new assembled corpus that
+can be loaded into the CauseMos system for interactive exploration.
+The dashboard is available at http://localhost:9444/dashboard by default. Here,
+you can enter some optional search criteria to find reader output records and
+click on "Find reader output records" to get a table of results. Once you
+identify an appropriate set, you can fill out the second form on the bottom
+with a corpus ID, display name and description, and then click on
+Run assembly to produce the results.
+
+Once a corpus is created, it can be loaded into CauseMos. INDRA World's REST
+API also allows incrementally assembling new content against an existing
+corpus.
+
+<a id="Reading and assembly"></a>
+### [Reading and assembly](index.html#reading-assembly)
+
+In this workflow INDRA World processes outputs from one or more reading systems
+(Eidos, Hume or Sofia) as input. We assume that each reading system was
+already run and produced a number of output files. INDRA World assembly can be
+done using the [command line interface](https://github.com/indralab/indra_world#command-line-interface)
+either natively (if an appropriate Python environment and INDRA World and its
+dependencies are installed) or through Docker.
+
+```
+indra_world --reader-output-files READER_OUTPUT_FILES --ontology-path ONTOLOGY_PATH --output-folder OUTPUT_FOLDER
+```
+
+In the above, `READER_OUTPUT_FILES` refers to a JSON file with the following
+structure
+```
+{
+ "eidos":
+ [
+ "/path/to/file1",
+ "/path/to/file2",
+ ],
+ "hume": [
+ ...
+ ]
+}
+```
+where keys are reading systems and values are lists of paths to their output
+files.
+
+`ONTOLOGY_PATH` is a path to a standard ontology YAML file.
+`OUTPUT_FOLDER` refers to a folder in which the resulting `statements.json`
+JSON-L dump of assembled INDRA Statements will be written. For more optional
+arguments, see the CLI documentation.

--- a/reading-assembly/indra_workflows.md
+++ b/reading-assembly/indra_workflows.md
@@ -36,7 +36,7 @@ API also allows incrementally assembling new content against an existing
 corpus.
 
 <a id="Reading and assembly"></a>
-### [Reading and assembly](index.html#reading-assembly)
+### [Reading and assembly](index.html#reading-and-assembly)
 
 In this workflow INDRA World processes outputs from one or more reading systems
 (Eidos, Hume or Sofia) as input. We assume that each reading system was


### PR DESCRIPTION
This PR restructures the INDRA World documentation into two parts and harmonizes it with the changed overview page for reading and assembly.