### PR TITLE
Restructure Sofia documentation into two parts

### DIFF
--- a/reading-assembly.md
+++ b/reading-assembly.md
@@ -121,7 +121,7 @@ outputs for downstream usage.
 The following pages provide detailed instructions for running each reading
 system in a reading-only workflow:
 
-  * Readers: one of [Eidos](reading-assembly/eidos_workflows.html#reading-only), [HUME](reading-assembly/hume_workflows.html#reading-and-assembly), [Sofia](reading-assembly/sofia.html#w1)
+  * Readers: one of [Eidos](reading-assembly/eidos_workflows.html#reading-only), [HUME](reading-assembly/hume_workflows.html#reading-only), [Sofia](reading-assembly/sofia_workflows.html#reading-only)
 
 <a id="w2"></a>
 ### Reading + integration/assembly
@@ -135,7 +135,7 @@ components to create a coherent knowledge base. This section describes
 the usage of these components independent of the integrated system.
 
 Systems used:
-  * Readers: one or more of [Eidos](reading-assembly/eidos_workflows.html#reading-and-assembly), [HUME](reading-assembly/hume_workflows.html#reading-only), or [Sofia](reading-assembly/sofia.html#w2)
+  * Readers: one or more of [Eidos](reading-assembly/eidos_workflows.html#reading-and-assembly), [HUME](reading-assembly/hume_workflows.html#reading-only), or [Sofia](reading-assembly/sofia_workflows.html#reading-and-assembly)
   * Integration/assembly: [INDRA](reading-assembly/indra_workflows.html#reading-and-assembly)
 
 
@@ -158,7 +158,7 @@ Systems used:
 
     Sofia is a machine reading system developed at CMU that extracts causal relations from text.
   
-    Workflows: [Reading only](reading-assembly/sofia.html#w1), [Reading and assembly](reading-assembly/sofia.html#w2), [Integrated](reading-assembly/sofia.html#w5)
+    Workflows: [Reading only](reading-assembly/sofia_workflows.html#reading-only), [Reading and assembly](reading-assembly/sofia_workflows.html#reading-and-assembly), [Integrated](reading-assembly/sofia_workflows.html#integrated-system)
 
 * Integration/assembly
   * [Indra World](reading-assembly/indra.html)

--- a/reading-assembly/hume.md
+++ b/reading-assembly/hume.md
@@ -3,6 +3,7 @@ title: HUME
 has_children: true
 parent: Causal Knowledge Extraction and Assembly Toolkit
 nav_order: 3
+has_toc: false
 ---
 # HUME
 

--- a/reading-assembly/hume_workflows.md
+++ b/reading-assembly/hume_workflows.md
@@ -3,7 +3,7 @@ title: HUME Workflows
 has_children: false
 parent: HUME
 grand_parent: Causal Knowledge Extraction and Assembly Toolkit
-nav_order: 3
+nav_order: 1
 ---
 # HUME Workflows
 Hume is a machine reading system developed by BBN. It extracts events and

--- a/reading-assembly/sofia.md
+++ b/reading-assembly/sofia.md
@@ -1,30 +1,37 @@
 ---
 title: Sofia
-has_children: false
+has_children: true
 parent: Causal Knowledge Extraction and Assembly Toolkit
 nav_order: 4
 ---
 # Sofia
 
+SOFIA is an Information Extraction system whose main goal is to extract Causal
+Relations that are explicitly mentioned in text, in order to facilitate
+automatic causal analysis graph construction.
+
+SOFIA extracts three major types of information: Entities, Events, and
+Causal-type Relations. All semantic units are important in order to build a
+coherent model useful for CAG construction. Entities include physical objects,
+people, organizations, etc., while events denote some actions, processes or
+changes of state. Entities are participants in events (e.g., the car moves),
+while events are arguments to relations like Causality (e.g., Reading causes
+Thinking).
+
+The detected Events and Entities are currently grounded to SOFIA's internal
+Ontology, We note that although the Ontology is subject to minor changes, we do
+not plan to change the Upper Level structure. Additional information provided by
+SOFIA includes Time, Location, Confidence Scores and Quantitative/Qualitative
+metrics of Entities.
+
+
 ## Disclaimer
 
-Development of the `SOFIA` Reader ended before a few key features were introduced to the World Modelers Machine Reading Pipeline. As a result, there are a number of caveats that must be taken into account in order to use `SOFIA` to produce Reader Outputs.
-
-1. **Ontology structure**
-
-    `SOFIA` works with an older version of the World Modelers Ontology structure. The latest version of the ontologies used by the other Readers uses an updated format that is not natively recognized `SOFIA`. There is a CLI tool for translating the ontology into something `SOFIA` can use that is provided with the [DART Concepts Explorer](https://github.com/twosixlabs-dart/dart-ui) project. Any ontologies developed with the *Ontology in a Day (OIAD)* workflow must be run through this utility first before `SOFIA` can use it. Instructions for running this utility can be found [here](https://github.com/twosixlabs-dart/dart-ui#translate-backwards).
-
-2. **No support for dynamic ontology loading**
-
-    `SOFIA` can only support a single ontology per instance of the application. It loads a static resource from the filesystem on startup and has not been integrated with the [Ontology Registry](https://github.com/twosixlabs-dart/ontology-registry). Furthermore, due to the necessity to adapt the ontology structure out-of-band, it is not currently possible to support the dynamic "hot swapping" of ontologies at runtime. Therefore, to utilize `SOFIA` to obtain Reader Outputs for the latest version of the *World Modelers Machine Reading Pipeline*, one of the following deployment scenarios must be chosen.
-    
-    a. Run multiple instances of the `SOFIA` application with different ontologies
-        `SOFIA` can be run as a realtime stream processor if the ontologies are stable and provided ahead of time. Provided that the ontology has been properly translated, you can run a single instance of the `SOFIA` application for each ontology. The file is specified with the `ONTOLOGY` environment variable when starting the Docker container.
-
-
-    b. Process the data "offline" in batches
-        The `SOFIA` Reader can also be run as an offline batch process. This scenario is also contingent on a set of stable ontologies being available ahead of time. To support this scenario, one can run `SOFIA` with the `KAFKA_AUTO_OFFSERT_RESET` parameter set to `earliest` to force it to process the entire CDR update stream each time. `SOFIA` can be run once per ontology to produce the desired Reader Outputs.
-
+Development of the `SOFIA` Reader ended before a few key features were
+introduced to the World Modelers Machine Reading Pipeline. As a result, there
+are a number of caveats that must be taken into account in order to use `SOFIA`
+to produce reader outputs. For more details, see the [Sofia Workflows](sofia_workflows.html)
+page.
 At the time of writing, the changes necessary to run `SOFIA` with the latest World Modelers configuration has not been merged into the `master` branch. One must use a Docker image that is based off of [this fork](https://github.com/twosixlabs-dart/WM-src) or [this branch](TODO) of the main repository. The following Docker compose configuration can be used to run `SOFIA` in order to support both of the scenarios outlined above:
 | Name                       | Description                                                          | Examples                                               |
 |----------------------------|----------------------------------------------------------------------|--------------------------------------------------------|

--- a/reading-assembly/sofia.md
+++ b/reading-assembly/sofia.md
@@ -3,6 +3,7 @@ title: Sofia
 has_children: true
 parent: Causal Knowledge Extraction and Assembly Toolkit
 nav_order: 4
+has_toc: false
 ---
 # Sofia
 

--- a/reading-assembly/sofia_workflows.md
+++ b/reading-assembly/sofia_workflows.md
@@ -1,0 +1,109 @@
+---
+title: Sofia Workflows
+has_children: false
+parent: Sofia
+grand_parent: Causal Knowledge Extraction and Assembly Toolkit
+nav_order: 1
+---
+
+# Sofia Workflows
+
+## Contents
+* [Integrated system](#integrated-system)
+* [Reading and assembly](#reading-and-assembly)
+* [Reading only](#reading-only)
+
+
+<a id="integrated-system"></a>
+### [Integrated system](index.html#integrated-system)
+ 
+There are several caveats related to running Sofia as part of the integrated
+system including the following.
+
+1. **Ontology structure**
+
+   `SOFIA` works with an older version of the World Modelers Ontology structure.
+   The latest version of the ontologies used by the other Readers uses an
+   updated format that is not natively recognized `SOFIA`. There is a CLI tool
+   for translating the ontology into something `SOFIA` can use that is provided
+   with the [DART Concepts Explorer](https://github.com/twosixlabs-dart/dart-ui)
+   project. Any ontologies developed with the *Ontology in a Day (OIAD)*
+   workflow must be run through this utility first before `SOFIA` can use it.
+   Instructions for running this utility can be
+   found [here](https://github.com/twosixlabs-dart/dart-ui#translate-backwards).
+
+2. **No support for dynamic ontology loading**
+
+   `SOFIA` can only support a single ontology per instance of the application.
+   It loads a static resource from the filesystem on startup and has not been
+   integrated with
+   the [Ontology Registry](https://github.com/twosixlabs-dart/ontology-registry)
+   . Furthermore, due to the necessity to adapt the ontology structure
+   out-of-band, it is not currently possible to support the dynamic "hot
+   swapping" of ontologies at runtime. Therefore, to utilize `SOFIA` to obtain
+   Reader Outputs for the latest version of the *World Modelers Machine Reading
+   Pipeline*, one of the following deployment scenarios must be chosen.
+
+   a. Run multiple instances of the `SOFIA` application with different ontologies
+
+   `SOFIA` can be run as a realtime stream processor if the ontologies are
+   stable and provided ahead of time. Provided that the ontology has been
+   properly translated, you can run a single instance of the `SOFIA` application
+   for each ontology. The file is specified with the `ONTOLOGY` environment
+   variable when starting the Docker container.
+
+    b. Process the data "offline" in batches
+
+    The `SOFIA` Reader can also be run
+    as an offline batch process. This scenario is also contingent on a set of
+    stable ontologies being available ahead of time. To support this scenario,
+    one can run `SOFIA` with the `KAFKA_AUTO_OFFSERT_RESET` parameter set
+    to `earliest` to force it to process the entire CDR update stream each
+    time. `SOFIA` can be run once per ontology to produce the desired Reader
+    Outputs.
+
+
+At the time of writing, the changes necessary to run `SOFIA` with the latest World Modelers configuration has not been merged into the `master` branch. One must use a Docker image that is based off of [this fork](https://github.com/twosixlabs-dart/WM-src) or [this branch](TODO) of the main repository. The following Docker compose configuration can be used to run `SOFIA` in order to support both of the scenarios outlined above:
+| Name                       | Description                                                          | Examples                                               |
+|----------------------------|----------------------------------------------------------------------|--------------------------------------------------------|
+| DART_KAFKA_BROKER_URL      | hostname of the Kafka broker that hosts the DART CDR stream          | kafka.dart.worldmodelers.com                           |
+| DART_READER_UPLOAD_API_URL | hostname of the DART Reader Output REST API                          | rest.dart.worldmodelers.com                            |
+| DART_CDR_API_URL           | hostname of the DART CDR Retrieval REST API                          | rest.dart.worldmodelers.com                            |
+| ONTOLOGY                   | fully qualified path to the ontology file (must be translated first) | /opt/app/conf/49277ea4-7182-46d2-ba4e-87800ee5a315.yml |
+| SOFIA_USER                 | DART username for the SOFIA Reader                                   | sofia                                                  |
+| SOFIA_PASS                 | DART password of the SOFIA Reader                                    | dart-password                                          |
+
+
+```yaml
+  sofia:
+    container_name: sofia
+    image: sofia:latest
+    environment:
+      KAFKA_BROKER: ${DART_KAFKA_BROKER_URL}:19092
+      UPLOAD_API_URL: http://${DART_READER_UPLOAD_API_URL}:13337/dart/api/v1/readers/upload
+      CDR_API_URL: http://${DART_CDR_API_URL}:8090/dart/api/v1/cdrs
+      KAFKA_AUTO_OFFSET_RESET: earliest
+      ONTOLOGY: /opt/app/conf/49277ea4-7182-46d2-ba4e-87800ee5a315.yml
+      SOFIA_USER: sofia
+      SOFIA_PASS: <SOFIA_DART_PASSWORD>
+    restart: unless-stopped
+    volumes:
+     - ./data/sofia:/sofia
+     - ./data/appdata:/opt/app/data
+    network_mode: host
+```
+
+
+<a id="reading-and-assembly"></a>
+### [Reading and assembly](index.html#reading-and-assembly) Reading + integration/assembly
+
+In this workflow, INDRA World is used to process the output files generated by Sofia.
+You can follow the instructions [below](#reading-only) to produce the output
+files first and then follow the INDRA World instructions to run assembly.
+<a id="w1"></a>
+
+<a id="reading-only"></a>
+### [Reading only](index.html#reading-only)
+
+In this workflow Sofia runs as a standalone reading system. Usage instructions
+for running Sofia on input documents is provided [here](https://github.com/spilioeve/WM-src#usage).


### PR DESCRIPTION
This PR restructures the Sofia documentation into two parts following the template for INDRA and Eidos, and restructures workflows to be consistent with the current integration page.